### PR TITLE
Add frontend layout with login page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,11 @@ All directories in this repository are covered by these guidelines. They describ
 ## Project Structure
 
 - **apps/** contains application source code:
-  - `frontend/` – Next.js frontend.
-  - `backend/` – AdonisJS backend written in TypeScript.
-  - `java-service/` – Java resource server secured by Zitadel.
+- `frontend/` – Next.js frontend.
+- `backend/` – AdonisJS backend written in TypeScript.
+- `java-service/` – Java resource server secured by Zitadel.
+
+The frontend uses Tailwind CSS with shadcn UI components. Keep UI code minimal and style via Tailwind classes.
 - **gateway/** holds configuration for Gloo API Gateway.
 - **iac/** provides infrastructure as code, including Kubernetes manifests.
 - **ops/** stores operational configurations such as Flux and Istio setup.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,3 +1,7 @@
 # Backend (AdonisJS)
 
-This directory contains a minimal TypeScript setup intended for an AdonisJS API. Build the code with `npm run build` and run it with `npm start`.
+This directory contains a minimal TypeScript setup intended for an AdonisJS API.
+
+Build the code with `npm run build` and run it with `npm start`.
+
+The server exposes `/auth/login` to initiate the Zitadel login and `/auth/callback` to handle the OAuth2 authorization code flow.

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,3 +1,34 @@
-import 'reflect-metadata';
+import 'reflect-metadata'
+import http from 'http'
+import { URL } from 'url'
 
-console.log('AdonisJS backend placeholder');
+const PORT = 4000
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    res.statusCode = 404
+    return res.end()
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`)
+
+  if (url.pathname === '/auth/login') {
+    // TODO: redirect to Zitadel authorization endpoint
+    res.writeHead(302, { Location: 'https://zitadel.example.com/oauth/v2/authorize' })
+    return res.end()
+  }
+
+  if (url.pathname === '/auth/callback') {
+    // TODO: exchange code for tokens and create session
+    console.log('Received auth code', url.searchParams.get('code'))
+    res.writeHead(302, { Location: 'http://localhost:3000/callback' })
+    return res.end()
+  }
+
+  res.statusCode = 404
+  res.end('Not found')
+})
+
+server.listen(PORT, () => {
+  console.log(`Backend listening on http://localhost:${PORT}`)
+})

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,3 +1,9 @@
 # Frontend (Next.js)
 
-This directory contains a minimal Next.js application used in the demo. Run `npm install` and `npm run dev` inside this folder to start the development server.
+This directory contains a minimal Next.js application used in the demo.
+
+## Development
+
+Run `npm install` and `npm run dev` inside this folder to start the development server.
+
+The frontend uses **Tailwind CSS** and basic components from **shadcn/ui**. A login page redirects to the backend which handles the Zitadel authorization code flow.

--- a/apps/frontend/components/layout.js
+++ b/apps/frontend/components/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      {children}
+    </div>
+  )
+}

--- a/apps/frontend/components/ui/button.js
+++ b/apps/frontend/components/ui/button.js
@@ -1,0 +1,27 @@
+import { cva } from 'class-variance-authority'
+import clsx from 'clsx'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export function Button({ className, variant, size, ...props }) {
+  return <button className={clsx(buttonVariants({ variant, size }), className)} {...props} />
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,6 +10,11 @@
   "dependencies": {
     "next": "^13.4.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0"
   }
 }

--- a/apps/frontend/pages/_app.js
+++ b/apps/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/apps/frontend/pages/callback.js
+++ b/apps/frontend/pages/callback.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Callback() {
+  const router = useRouter()
+
+  useEffect(() => {
+    // After backend processes the code it will redirect here
+    // We simply navigate to home page
+    router.replace('/')
+  }, [router])
+
+  return <p className="text-center">Processing login...</p>
+}

--- a/apps/frontend/pages/index.js
+++ b/apps/frontend/pages/index.js
@@ -1,8 +1,12 @@
+import Layout from '../components/layout'
+
 export default function Home() {
   return (
-    <main>
-      <h1>Auth Federation Demo</h1>
-      <p>This is a minimal Next.js frontend.</p>
-    </main>
-  );
+    <Layout>
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Auth Federation Demo</h1>
+        <p className="text-gray-700">This is a minimal Next.js frontend.</p>
+      </div>
+    </Layout>
+  )
 }

--- a/apps/frontend/pages/login.js
+++ b/apps/frontend/pages/login.js
@@ -1,0 +1,18 @@
+import Layout from '../components/layout'
+import { Button } from '../components/ui/button'
+
+export default function Login() {
+  return (
+    <Layout>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-center">Login</h1>
+        <p className="text-center">Sign in using Zitadel</p>
+        <div className="flex justify-center">
+          <a href="http://localhost:4000/auth/login">
+            <Button>Login with Zitadel</Button>
+          </a>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/apps/frontend/styles/globals.css
+++ b/apps/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- implement basic Tailwind/shadcn setup for the Next.js frontend
- add login page linked to backend auth endpoints
- stub backend routes for Zitadel authorization code flow
- document new flow in READMEs
- mention shadcn and Tailwind in AGENTS guidelines

## Testing
- `git status --short`
