### PR TITLE
Add IAC provisioning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Each directory contains a `README.md` explaining how to deploy the component.
 ## Getting Started
 
 1. Install Docker and a local Kubernetes distribution (Kind or Minikube).
-2. Clone this repository and navigate to the `iac/clusters` directory to bootstrap the cluster.
-3. Apply the manifests in `iac/zitadel` to deploy Zitadel with PostgreSQL.
-4. Deploy Permit.io from `iac/permitio`.
-5. Deploy monitoring components from `iac/monitoring`.
-6. Deploy the applications under `apps/` using the GitOps configuration in `ops/flux`.
+2. Clone this repository. Detailed provisioning steps are provided in `iac/README.md`.
+3. Navigate to `iac/clusters` to create the Kubernetes cluster.
+4. Apply the manifests in `iac/zitadel` to deploy Zitadel with PostgreSQL.
+5. Deploy Permit.io from `iac/permitio`.
+6. Deploy monitoring components from `iac/monitoring`.
+7. Deploy the applications under `apps/` using the GitOps configuration in `ops/flux`.
 
 This project is a work in progress and serves as a starting point. Contributions are welcome!
 

--- a/iac/README.md
+++ b/iac/README.md
@@ -1,0 +1,25 @@
+# Infrastructure as Code (IAC)
+
+This directory contains manifests and configuration files for provisioning the Kubernetes environment and core services used by the demo. The workflow below uses [`kubectl`](https://kubernetes.io/docs/tasks/tools/) along with either [`kind`](https://kind.sigs.k8s.io/) or [`minikube`](https://minikube.sigs.k8s.io/).
+
+## Quickstart
+
+1. Install `kubectl` and your preferred local Kubernetes distribution.
+2. Create a cluster:
+   - **Kind**:
+     ```bash
+     kind create cluster --name auth-demo --config clusters/kind-cluster.yaml
+     ```
+   - **Minikube**:
+     ```bash
+     minikube start
+     ```
+3. Deploy core services using the manifests in this directory:
+   ```bash
+   kubectl apply -f zitadel/
+   kubectl apply -f permitio/
+   kubectl apply -f monitoring/
+   ```
+4. Continue with the application deployments as described under `ops/`.
+
+Refer to each subdirectory `README.md` for additional options and configuration details.

--- a/iac/clusters/README.md
+++ b/iac/clusters/README.md
@@ -1,3 +1,25 @@
 # Cluster Setup
 
-Scripts and configuration for creating the local Kubernetes cluster (Kind/Minikube).
+This directory provides configuration files for creating the local Kubernetes cluster used by the demo. A minimal `kind-cluster.yaml` is included and can be used with the `kind` tool. Alternatively you can start a Minikube cluster.
+
+## Using Kind
+
+1. Install [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/).
+2. Run the following command from the repository root:
+   ```bash
+   kind create cluster --name auth-demo --config iac/clusters/kind-cluster.yaml
+   ```
+3. Verify the cluster is running:
+   ```bash
+   kubectl get nodes
+   ```
+
+## Using Minikube
+
+1. Install [`minikube`](https://minikube.sigs.k8s.io/docs/start/).
+2. Start a cluster:
+   ```bash
+   minikube start
+   ```
+
+Both approaches produce a Kubernetes environment ready for applying the manifests in the other `iac` directories.


### PR DESCRIPTION
## Summary
- document how to provision the cluster and components using IAC
- expand cluster README with kind/minikube steps
- link to the new instructions from the main README

## Testing
- `git status --short`