### PR TITLE
Add Terraform module for Zitadel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The goal is to run the entire stack locally using Kubernetes (e.g., with [Kind](
 │   ├── clusters/       # Kubernetes cluster configuration
 │   ├── zitadel/        # Helm charts or manifests for Zitadel and PostgreSQL
 │   ├── permitio/       # Permit.io deployment manifests
-│   └── monitoring/     # Prometheus/Grafana manifests and dashboards
+│   ├── monitoring/     # Prometheus/Grafana manifests and dashboards
+│   └── terraform/      # Terraform modules (e.g., Zitadel configuration)
 ├── gateway/            # Gloo API Gateway configuration
 ├── apps/
 │   ├── frontend/       # Next.js application

--- a/iac/README.md
+++ b/iac/README.md
@@ -22,4 +22,7 @@ This directory contains manifests and configuration files for provisioning the K
    ```
 4. Continue with the application deployments as described under `ops/`.
 
+Terraform modules live under `terraform/` for provisioning additional
+resources such as Zitadel entities.
+
 Refer to each subdirectory `README.md` for additional options and configuration details.

--- a/iac/terraform/README.md
+++ b/iac/terraform/README.md
@@ -1,0 +1,5 @@
+# Terraform Modules
+
+This directory contains Terraform code used to provision cloud resources for the demo environment. The initial module provisions Zitadel entities using the `zitadel/zitadel` provider.
+
+Run `terraform init` and `terraform apply` inside each module directory after configuring the necessary provider credentials.

--- a/iac/terraform/zitadel/README.md
+++ b/iac/terraform/zitadel/README.md
@@ -1,0 +1,18 @@
+# Zitadel Terraform Module
+
+This module demonstrates how to provision Zitadel resources with Terraform. It creates an organization, a project, and a service user as a placeholder for the applications in this repository.
+
+Before running Terraform, export a personal access token:
+
+```bash
+export ZITADEL_TOKEN="<your-pat>"
+```
+
+Copy `terraform.tfvars.example` to `terraform.tfvars` and update the domain if needed.
+
+Initialize and apply the module:
+
+```bash
+terraform init
+terraform apply
+```

--- a/iac/terraform/zitadel/main.tf
+++ b/iac/terraform/zitadel/main.tf
@@ -1,0 +1,30 @@
+variable "zitadel_domain" {
+  description = "Domain of the Zitadel instance"
+  type        = string
+}
+
+variable "zitadel_token" {
+  description = "Personal access token for API calls"
+  type        = string
+  sensitive   = true
+}
+
+provider "zitadel" {
+  domain                = var.zitadel_domain
+  personal_access_token = var.zitadel_token
+}
+
+# Placeholder resources for the demo environment
+resource "zitadel_org" "demo" {
+  name = "demo-org"
+}
+
+resource "zitadel_project" "demo" {
+  org_id = zitadel_org.demo.id
+  name   = "demo-project"
+}
+
+resource "zitadel_service_user" "backend" {
+  org_id   = zitadel_org.demo.id
+  username = "backend-service"
+}

--- a/iac/terraform/zitadel/terraform.tfvars.example
+++ b/iac/terraform/zitadel/terraform.tfvars.example
@@ -1,0 +1,2 @@
+zitadel_domain = "example.zitadel.cloud"
+zitadel_token  = "<your-pat>"

--- a/iac/terraform/zitadel/versions.tf
+++ b/iac/terraform/zitadel/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create Terraform directory for provider modules
- add a sample module to provision Zitadel resources
- document how to run the module

## Testing
- `git status --short`
- `terraform` not installed so no tests to run